### PR TITLE
Add strict and loose schma functions

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,2 @@
-{:lint-as {org.httpkit.client/defreq clojure.core/def}
- :clean {:automatically-after-ns-refactor true
-         :ns-inner-blocks-indentation :same-line}}
+{:linters {:missing-else-branch {:level :off}
+           :clojure-lsp/unused-public-var {:level :off}}}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,0 +1,2 @@
+{:clean {:automatically-after-ns-refactor true
+         :ns-inner-blocks-indentation :same-line}}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,16 @@
-(defproject fakeflix-schema "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+(defproject fakeflix-schema "1.0.0"
+  :description "Fakeflix Schema library"
+  :url "https://pedroteles.dev"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.3"]]
-  :repl-options {:init-ns fakeflix-schema.core})
+  :plugins [[com.github.clojure-lsp/lein-clojure-lsp "1.3.9"]]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [prismatic/schema "1.2.1"]
+                 [nubank/matcher-combinators "3.5.1"]]
+  :aliases {"diagnostics"  ["clojure-lsp" "diagnostics"]
+            "format"       ["clojure-lsp" "format" "--dry"]
+            "format-fix"   ["clojure-lsp" "format"]
+            "clean-ns"     ["clojure-lsp" "clean-ns" "--dry"]
+            "clean-ns-fix" ["clojure-lsp" "clean-ns"]
+            "lint"         ["do" ["diagnostics"] ["format"] ["clean-ns"]]
+            "lint-fix"     ["do" ["format-fix"] ["clean-ns-fix"]]})

--- a/src/fakeflix_schema/core.clj
+++ b/src/fakeflix_schema/core.clj
@@ -1,6 +1,0 @@
-(ns fakeflix-schema.core)
-
-(defn foo
-  "I don't do a whole lot."
-  [x]
-  (println x "Hello, World!"))

--- a/src/fakeflix_schema/schema.clj
+++ b/src/fakeflix_schema/schema.clj
@@ -1,0 +1,29 @@
+(ns fakeflix-schema.schema
+  (:require [schema.core :as s]))
+
+(s/defn keyword-skeleton->keyword-schema
+  [skeleton :- [s/Any]]
+  (let [keyword (first skeleton)
+        attributes (second skeleton)
+        required? (:required attributes)
+        schema (:schema attributes)]
+    (if required?
+      {keyword schema}
+      {(s/optional-key keyword) schema})))
+
+(s/defn skeleton->schema :- {s/Any s/Any}
+  [skeleton :- {s/Keyword {s/Keyword s/Any}}]
+  (->> skeleton
+       seq
+       (map keyword-skeleton->keyword-schema)
+       (reduce merge)))
+
+(s/defn strict-schema :- {s/Any s/Any}
+  [skeleton :- {s/Keyword {s/Keyword s/Any}}]
+  (skeleton->schema skeleton))
+
+(s/defn loose-schema :- {s/Any s/Any}
+  [skeleton :- {s/Keyword {s/Keyword s/Any}}]
+  (-> skeleton
+      skeleton->schema
+      (assoc s/Any s/Any)))

--- a/test/fakeflix_schema/core_test.clj
+++ b/test/fakeflix_schema/core_test.clj
@@ -1,7 +1,0 @@
-(ns fakeflix-schema.core-test
-  (:require [clojure.test :refer :all]
-            [fakeflix-schema.core :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/test/fakeflix_schema/schema_test.clj
+++ b/test/fakeflix_schema/schema_test.clj
@@ -1,0 +1,55 @@
+(ns fakeflix-schema.schema-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [fakeflix-schema.schema :as schema]
+            [matcher-combinators.test :refer [match?]]
+            [schema.core :as s]))
+
+(deftest loose-schema-test
+  (testing "Should create the correct loose schema for required fields"
+    (is (match? {:test s/Str
+                 s/Any s/Any}
+                (schema/loose-schema {:test {:schema s/Str :required true}})))
+
+    (is (match? {:test  s/Str
+                 :test2 s/Num
+                 s/Any  s/Any}
+                (schema/loose-schema {:test  {:schema s/Str :required true}
+                                      :test2 {:schema s/Num :required true}}))))
+
+  (testing "Should create the correct loose schema for optional fields"
+    (is (match? {(s/optional-key :test) s/Str
+                 s/Any                  s/Any}
+                (schema/loose-schema {:test {:schema s/Str :required false}})))
+
+    (is (match? {:test                   s/Str
+                 (s/optional-key :test2) s/Num
+                 s/Any                   s/Any}
+                (schema/loose-schema {:test  {:schema s/Str :required true}
+                                      :test2 {:schema s/Num :required false}})))))
+
+(deftest strict-schema-test
+  (testing "Should create the correct strict schema for required fields"
+    (is (match? {:test s/Str}
+                (schema/strict-schema {:test {:schema s/Str :required true}})))
+
+    (is (match? {:test  s/Str
+                 :test2 s/Num}
+                (schema/strict-schema {:test  {:schema s/Str :required true}
+                                       :test2 {:schema s/Num :required true}}))))
+
+  (testing "Should create the correct strict schema for optional fields"
+    (is (match? {(s/optional-key :test) s/Str}
+                (schema/strict-schema {:test {:schema s/Str :required false}})))
+
+    (is (match? {:test                   s/Str
+                 (s/optional-key :test2) s/Num}
+                (schema/strict-schema {:test  {:schema s/Str :required true}
+                                       :test2 {:schema s/Num :required false}})))))
+
+(deftest keyword-skeleton->keyword-schema-test
+  (testing "Should return a map containing the keyword and the schema type"
+    (is (match? {:test s/Str}
+                (schema/keyword-skeleton->keyword-schema [:test {:schema s/Str :required true}])))
+
+    (is (match? {(s/optional-key :test) s/Str}
+                (schema/keyword-skeleton->keyword-schema [:test {:schema s/Str :required false}])))))


### PR DESCRIPTION
Add functions to create both strict (can accept only what is definied in the skeleton) and loose (can accept and ignore other fields that isn't defined in the skeleton) schemas